### PR TITLE
Add prettier overrides in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,5 +85,10 @@
       "pnpm check:spelling"
     ]
   },
-  "packageManager": "pnpm@10.7.1"
+  "packageManager": "pnpm@10.7.1",
+  "pnpm": {
+    "overrides": {
+      "prettier": "3.5.3"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  prettier: 3.5.3
+
 importers:
 
   .:
@@ -75,7 +78,7 @@ importers:
         specifier: ^15.5.0
         version: 15.5.0
       prettier:
-        specifier: ^3.5.3
+        specifier: 3.5.3
         version: 3.5.3
       ts-morph:
         specifier: ^25.0.1
@@ -659,17 +662,17 @@ importers:
         specifier: workspace:*
         version: link:../prettier-plugin-package-json
       prettier:
-        specifier: 3.x
-        version: 3.4.2
+        specifier: 3.5.3
+        version: 3.5.3
       prettier-plugin-prisma:
         specifier: ^5.0.0
-        version: 5.0.0(prettier@3.4.2)
+        version: 5.0.0(prettier@3.5.3)
       prettier-plugin-sort-json:
         specifier: ^4.1.1
-        version: 4.1.1(prettier@3.4.2)
+        version: 4.1.1(prettier@3.5.3)
       prettier-plugin-tailwindcss:
         specifier: ^0.6.11
-        version: 0.6.11(prettier@3.4.2)
+        version: 0.6.11(prettier@3.5.3)
     devDependencies:
       '@tszhong0411/eslint-config':
         specifier: workspace:*
@@ -681,8 +684,8 @@ importers:
   packages/prettier-plugin-package-json:
     dependencies:
       prettier:
-        specifier: 3.x
-        version: 3.4.2
+        specifier: 3.5.3
+        version: 3.5.3
       prettier-package-json:
         specifier: ^2.8.0
         version: 2.8.0
@@ -6854,7 +6857,7 @@ packages:
       '@types/eslint': '>=8.0.0'
       eslint: '>=8.0.0'
       eslint-config-prettier: '>= 7.0.0 <10.0.0 || >=10.1.0'
-      prettier: '>=3.0.0'
+      prettier: 3.5.3
     peerDependenciesMeta:
       '@types/eslint':
         optional: true
@@ -9369,13 +9372,13 @@ packages:
     resolution: {integrity: sha512-jTJV04D9+yF7ziOOMs7CJe4ijgAH7DEGjt0SAWAToGNRy1H6BEhvcKA2UQH6gC6KVW5zeeOSAvsoiDDTt9oKXg==}
     engines: {node: '>=14', npm: '>=8'}
     peerDependencies:
-      prettier: '>=2 || >=3'
+      prettier: 3.5.3
 
   prettier-plugin-sort-json@4.1.1:
     resolution: {integrity: sha512-uJ49wCzwJ/foKKV4tIPxqi4jFFvwUzw4oACMRG2dcmDhBKrxBv0L2wSKkAqHCmxKCvj0xcCZS4jO2kSJO/tRJw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      prettier: ^3.0.0
+      prettier: 3.5.3
 
   prettier-plugin-tailwindcss@0.6.11:
     resolution: {integrity: sha512-YxaYSIvZPAqhrrEpRtonnrXdghZg1irNg4qrjboCXrpybLWVs55cW2N3juhspVJiO0JBvYJT8SYsJpc8OQSnsA==}
@@ -9386,7 +9389,7 @@ packages:
       '@shopify/prettier-plugin-liquid': '*'
       '@trivago/prettier-plugin-sort-imports': '*'
       '@zackad/prettier-plugin-twig': '*'
-      prettier: ^3.0
+      prettier: 3.5.3
       prettier-plugin-astro: '*'
       prettier-plugin-css-order: '*'
       prettier-plugin-import-sort: '*'
@@ -9431,16 +9434,6 @@ packages:
         optional: true
       prettier-plugin-svelte:
         optional: true
-
-  prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-
-  prettier@3.4.2:
-    resolution: {integrity: sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==}
-    engines: {node: '>=14'}
-    hasBin: true
 
   prettier@3.5.3:
     resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
@@ -12207,7 +12200,7 @@ snapshots:
       fs-extra: 7.0.1
       lodash.startcase: 4.4.0
       outdent: 0.5.0
-      prettier: 2.8.8
+      prettier: 3.5.3
       resolve-from: 5.0.0
       semver: 7.7.1
 
@@ -12335,7 +12328,7 @@ snapshots:
       '@changesets/types': 6.1.0
       fs-extra: 7.0.1
       human-id: 4.1.1
-      prettier: 2.8.8
+      prettier: 3.5.3
 
   '@clerc/core@0.44.0':
     dependencies:
@@ -14694,7 +14687,7 @@ snapshots:
   '@react-email/render@1.0.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       html-to-text: 9.0.5
-      prettier: 3.4.2
+      prettier: 3.5.3
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-promise-suspense: 0.3.4
@@ -21086,22 +21079,18 @@ snapshots:
       sort-object-keys: 1.1.3
       sort-order: 1.1.2
 
-  prettier-plugin-prisma@5.0.0(prettier@3.4.2):
+  prettier-plugin-prisma@5.0.0(prettier@3.5.3):
     dependencies:
       '@prisma/prisma-schema-wasm': 4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584
-      prettier: 3.4.2
+      prettier: 3.5.3
 
-  prettier-plugin-sort-json@4.1.1(prettier@3.4.2):
+  prettier-plugin-sort-json@4.1.1(prettier@3.5.3):
     dependencies:
-      prettier: 3.4.2
+      prettier: 3.5.3
 
-  prettier-plugin-tailwindcss@0.6.11(prettier@3.4.2):
+  prettier-plugin-tailwindcss@0.6.11(prettier@3.5.3):
     dependencies:
-      prettier: 3.4.2
-
-  prettier@2.8.8: {}
-
-  prettier@3.4.2: {}
+      prettier: 3.5.3
 
   prettier@3.5.3: {}
 


### PR DESCRIPTION
### Description

Fixed below error:

```
⚠ ./node_modules/.pnpm/@react-email+render@1.0.5_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/@react-email/render/dist/node
Package prettier can't be external
The request prettier/standalone matches serverExternalPackages (or the default list).
The package resolves to a different version when requested from the project directory (3.5.3) compared to the package requested from the importing module (3.4.2).
Make sure to install the same version of the package in both locations.
```