### PR TITLE
fix: normalize IP extraction for session utils

### DIFF
--- a/apps/web/src/tests/unit/utils/get-ip.test.ts
+++ b/apps/web/src/tests/unit/utils/get-ip.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { getIp } from '@/utils/get-ip'
+
+describe('getIp', () => {
+  it('returns the first IP from the x-forwarded-for header', () => {
+    const headers = new Headers({
+      'x-forwarded-for': '203.0.113.4, 70.41.3.18, 150.172.238.178'
+    })
+
+    expect(getIp(headers)).toBe('203.0.113.4')
+  })
+
+  it('falls back to the x-real-ip header when x-forwarded-for is missing', () => {
+    const headers = new Headers({ 'x-real-ip': '198.51.100.23' })
+
+    expect(getIp(headers)).toBe('198.51.100.23')
+  })
+
+  it('returns a default value when no headers are present', () => {
+    expect(getIp(new Headers())).toBe('0.0.0.0')
+  })
+})

--- a/apps/web/src/utils/get-ip.ts
+++ b/apps/web/src/utils/get-ip.ts
@@ -1,3 +1,22 @@
 export const getIp = (headers: Headers) => {
-  return headers.get('x-forwarded-for') ?? '0.0.0.0'
+  const forwardedFor = headers.get('x-forwarded-for')
+
+  if (forwardedFor) {
+    const ip = forwardedFor
+      .split(',')
+      .map((entry) => entry.trim())
+      .find(Boolean)
+
+    if (ip) {
+      return ip
+    }
+  }
+
+  const realIp = headers.get('x-real-ip')
+
+  if (realIp) {
+    return realIp
+  }
+
+  return '0.0.0.0'
 }


### PR DESCRIPTION
## Summary
- normalize IP parsing to prefer the first forwarded address with sensible fallbacks
- add unit coverage for getIp header parsing scenarios

## Testing
- pnpm format:check
- pnpm test:unit -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d81869cf90832c95d05c6c6005d44e