### PR TITLE
refactor: extend web content collection metadata

### DIFF
--- a/apps/web/content-collections.ts
+++ b/apps/web/content-collections.ts
@@ -9,23 +9,87 @@ type BaseDoc = {
   content: string
 }
 
-const transform = async <D extends BaseDoc>(document: D, context: Context) => {
-  const code = await compileMDX(context, document, {
-    remarkPlugins,
-    rehypePlugins
-  })
-  const [locale, path] = document._meta.path.split(/[/\\]/)
+type TransformOptions = {
+  routeBase?: string
+  coverImageBasePath?: string
+}
 
-  if (!locale || !path) {
-    throw new Error(`Invalid path: ${document._meta.path}`)
+const ensureLeadingSlash = (value: string) => {
+  if (!value) {
+    return ''
   }
 
-  return {
-    ...document,
-    code,
-    locale,
-    slug: path,
-    toc: await getTOC(document.content)
+  return value.startsWith('/') ? value : `/${value}`
+}
+
+const ensureNoTrailingSlash = (value: string) => {
+  if (value.length <= 1) {
+    return value
+  }
+
+  return value.endsWith('/') ? value.slice(0, -1) : value
+}
+
+const toPosixPath = (value: string) => value.replaceAll('\\', '/')
+
+const getPathname = (routeBase: string, slug: string) => {
+  const normalizedBase = ensureNoTrailingSlash(ensureLeadingSlash(routeBase))
+  const normalizedSlug = slug === 'index' ? '' : `/${slug}`
+  const pathname = `${normalizedBase}${normalizedSlug}`
+
+  return pathname === '' ? '/' : pathname
+}
+
+const getOgImagePathname = (pathname: string) => {
+  return `${pathname === '/' ? '' : pathname}/og-image.png`
+}
+
+const getCoverImagePathname = (coverImageBasePath: string | undefined, slug: string) => {
+  if (!coverImageBasePath) {
+    return
+  }
+
+  const normalizedBase = ensureNoTrailingSlash(ensureLeadingSlash(coverImageBasePath))
+
+  return `${normalizedBase}/${slug}/cover.png`
+}
+
+const getSourceFilePath = (context: Context, document: BaseDoc) => {
+  const segments = ['apps/web', context.collection.directory, document._meta.filePath]
+
+  return toPosixPath(segments.join('/'))
+}
+
+const createTransform = (options: TransformOptions = {}) => {
+  const { routeBase = '', coverImageBasePath } = options
+
+  return async <D extends BaseDoc>(document: D, context: Context) => {
+    const code = await compileMDX(context, document, {
+      remarkPlugins,
+      rehypePlugins
+    })
+    const [locale, path] = document._meta.path.split(/[/\\]/)
+
+    if (!locale || !path) {
+      throw new Error(`Invalid path: ${document._meta.path}`)
+    }
+
+    const pathname = getPathname(routeBase, path)
+    const ogImagePathname = getOgImagePathname(pathname)
+    const coverImagePathname = getCoverImagePathname(coverImageBasePath, path)
+    const sourceFilePath = getSourceFilePath(context, document)
+
+    return {
+      ...document,
+      code,
+      locale,
+      slug: path,
+      pathname,
+      ogImagePathname,
+      ...(coverImagePathname ? { coverImagePathname } : {}),
+      sourceFilePath,
+      toc: await getTOC(document.content)
+    }
   }
 }
 
@@ -39,7 +103,10 @@ const posts = defineCollection({
     modifiedTime: z.string(),
     summary: z.string()
   }),
-  transform
+  transform: createTransform({
+    routeBase: '/blog',
+    coverImageBasePath: '/images/blog'
+  })
 })
 
 const projects = defineCollection({
@@ -55,7 +122,10 @@ const projects = defineCollection({
     selected: z.boolean().optional().default(false),
     dateCreated: z.string()
   }),
-  transform
+  transform: createTransform({
+    routeBase: '/projects',
+    coverImageBasePath: '/images/projects'
+  })
 })
 
 const pages = defineCollection({
@@ -63,7 +133,7 @@ const pages = defineCollection({
   directory: 'src/content/pages',
   include: '**/*.mdx',
   schema: z.object({}),
-  transform
+  transform: createTransform()
 })
 
 export default defineConfig({

--- a/apps/web/src/app/[locale]/(main)/about/og-image.png/route.tsx
+++ b/apps/web/src/app/[locale]/(main)/about/og-image.png/route.tsx
@@ -24,7 +24,7 @@ export const GET = async (_request: Request, props: RouteContext<'/[locale]/abou
 
     const ogImageFonts = await getOGImageFonts(title)
 
-    return new ImageResponse(<OGImage title={title} url='/about' />, {
+    return new ImageResponse(<OGImage title={title} url={page.pathname} />, {
       width: OG_IMAGE_WIDTH,
       height: OG_IMAGE_HEIGHT,
       fonts: ogImageFonts

--- a/apps/web/src/app/[locale]/(main)/about/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/about/page.tsx
@@ -28,13 +28,18 @@ export const generateMetadata = async (props: PageProps<'/[locale]/about'>): Pro
   const { params } = props
   const { locale } = await params
   const t = await getTranslations({ locale, namespace: 'about' })
+  const page = allPages.find((p) => p.slug === 'about' && p.locale === locale)
+
+  if (!page) {
+    return {}
+  }
 
   return createMetadata({
-    pathname: '/about',
+    pathname: page.pathname,
     title: t('title'),
     description: t('description'),
     locale,
-    ogImagePathname: '/about/og-image.png',
+    ogImagePathname: page.ogImagePathname,
     openGraph: {
       type: 'profile'
     }
@@ -48,8 +53,14 @@ const Page = async (props: PageProps<'/[locale]/about'>) => {
   const t = await getTranslations()
   const title = t('about.title')
   const description = t('about.description')
-  const url = getLocalizedPath({ locale, pathname: '/about' })
   const page = allPages.find((p) => p.slug === 'about' && p.locale === locale)
+
+  if (!page) {
+    return notFound()
+  }
+
+  const { code, pathname } = page
+  const url = getLocalizedPath({ locale, pathname })
 
   const jsonLd: WithContext<AboutPage> = {
     '@context': 'https://schema.org',
@@ -66,12 +77,6 @@ const Page = async (props: PageProps<'/[locale]/about'>) => {
     },
     inLanguage: locale
   }
-
-  if (!page) {
-    return notFound()
-  }
-
-  const { code } = page
 
   return (
     <>

--- a/apps/web/src/app/[locale]/(main)/blog/[slug]/footer.tsx
+++ b/apps/web/src/app/[locale]/(main)/blog/[slug]/footer.tsx
@@ -2,7 +2,7 @@
 
 import type { Post } from '@/lib/content'
 
-import { useLocale, useTranslations } from '@repo/i18n/client'
+import { useTranslations } from '@repo/i18n/client'
 import { linkVariants } from '@repo/ui/components/link'
 
 import Link from '@/components/link'
@@ -15,9 +15,8 @@ type FooterProps = {
 const Footer = (props: FooterProps) => {
   const { post } = props
   const t = useTranslations()
-  const locale = useLocale()
 
-  const editURL = `https://github.com/nelsonlaidev/nelsonlai.dev/blob/main/apps/web/src/content/blog/${locale}/${post.slug}.mdx?plain=1`
+  const editURL = `https://github.com/nelsonlaidev/nelsonlai.dev/blob/main/${post.sourceFilePath}?plain=1`
 
   const formattedDate = useFormattedDate(post.modifiedTime)
 

--- a/apps/web/src/app/[locale]/(main)/blog/[slug]/header.tsx
+++ b/apps/web/src/app/[locale]/(main)/blog/[slug]/header.tsx
@@ -80,7 +80,7 @@ const Header = (props: HeaderProps) => {
       </div>
       <ImageZoom>
         <BlurImage
-          src={`/images/blog/${post.slug}/cover.png`}
+          src={post.coverImagePathname}
           className='rounded-lg'
           width={1200}
           height={630}

--- a/apps/web/src/app/[locale]/(main)/blog/[slug]/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/blog/[slug]/page.tsx
@@ -37,11 +37,11 @@ export const generateMetadata = async (props: PageProps<'/[locale]/blog/[slug]'>
   if (!post) return {}
 
   return createMetadata({
-    pathname: `/blog/${slug}`,
+    pathname: post.pathname,
     title: post.title,
     description: post.summary,
     locale,
-    ogImagePathname: `/blog/${post.slug}/og-image.png`,
+    ogImagePathname: post.ogImagePathname,
     openGraph: {
       type: 'article',
       publishedTime: post.date,
@@ -56,12 +56,13 @@ const Page = async (props: PageProps<'/[locale]/blog/[slug]'>) => {
   setRequestLocale(locale)
 
   const post = allPosts.find((p) => p.slug === slug && p.locale === locale)
-  const url = getLocalizedPath({ locale, pathname: `/blog/${slug}` })
-  const baseUrl = getBaseUrl()
 
   if (!post) {
     notFound()
   }
+
+  const url = getLocalizedPath({ locale, pathname: post.pathname })
+  const baseUrl = getBaseUrl()
 
   const jsonLd: WithContext<BlogPosting> = {
     '@context': 'https://schema.org',
@@ -72,7 +73,7 @@ const Page = async (props: PageProps<'/[locale]/blog/[slug]'>) => {
       '@type': 'WebPage',
       '@id': url
     },
-    image: `${baseUrl}/blog/${post.slug}/og-image.png`,
+    image: `${baseUrl}${post.ogImagePathname}`,
     datePublished: post.date,
     dateModified: post.modifiedTime,
     author: {

--- a/apps/web/src/app/[locale]/(main)/blog/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/blog/page.tsx
@@ -55,14 +55,18 @@ const Page = async (props: PageProps<'/[locale]/blog'>) => {
     url,
     mainEntity: {
       '@type': 'ItemList',
-      itemListElement: posts.map((post, index) => ({
-        '@type': 'BlogPosting',
-        headline: post.title,
-        url: `${url}/${post.slug}`,
-        datePublished: post.date,
-        dateModified: post.modifiedTime,
-        position: index + 1
-      }))
+      itemListElement: posts.map((post, index) => {
+        const postUrl = getLocalizedPath({ locale, pathname: post.pathname })
+
+        return {
+          '@type': 'BlogPosting',
+          headline: post.title,
+          url: postUrl,
+          datePublished: post.date,
+          dateModified: post.modifiedTime,
+          position: index + 1
+        }
+      })
     },
     isPartOf: {
       '@type': 'WebSite',

--- a/apps/web/src/app/[locale]/(main)/privacy/og-image.png/route.tsx
+++ b/apps/web/src/app/[locale]/(main)/privacy/og-image.png/route.tsx
@@ -24,7 +24,7 @@ export const GET = async (_request: Request, props: RouteContext<'/[locale]/priv
 
     const ogImageFonts = await getOGImageFonts(title)
 
-    return new ImageResponse(<OGImage title={title} url='/privacy' />, {
+    return new ImageResponse(<OGImage title={title} url={page.pathname} />, {
       width: OG_IMAGE_WIDTH,
       height: OG_IMAGE_HEIGHT,
       fonts: ogImageFonts

--- a/apps/web/src/app/[locale]/(main)/privacy/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/privacy/page.tsx
@@ -19,13 +19,18 @@ export const generateMetadata = async (props: PageProps<'/[locale]/privacy'>): P
   const t = await getTranslations({ locale, namespace: 'privacy' })
   const title = t('title')
   const description = t('description')
+  const page = allPages.find((p) => p.slug === 'privacy' && p.locale === locale)
+
+  if (!page) {
+    return {}
+  }
 
   return createMetadata({
-    pathname: '/privacy',
+    pathname: page.pathname,
     title,
     description,
     locale,
-    ogImagePathname: '/privacy/og-image.png'
+    ogImagePathname: page.ogImagePathname
   })
 }
 

--- a/apps/web/src/app/[locale]/(main)/projects/[slug]/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/projects/[slug]/page.tsx
@@ -32,14 +32,14 @@ export const generateMetadata = async (props: PageProps<'/[locale]/projects/[slu
     return {}
   }
 
-  const { name, description } = project
+  const { name, description, pathname, ogImagePathname } = project
 
   return createMetadata({
-    pathname: `/projects/${slug}`,
+    pathname,
     title: name,
     description,
     locale,
-    ogImagePathname: `/projects/${slug}/og-image.png`
+    ogImagePathname
   })
 }
 
@@ -49,13 +49,13 @@ const Page = async (props: PageProps<'/[locale]/projects/[slug]'>) => {
   setRequestLocale(locale)
 
   const project = allProjects.find((p) => p.slug === slug && p.locale === locale)
-  const url = getLocalizedPath({ locale, pathname: `/projects/${slug}` })
 
   if (!project) {
     notFound()
   }
 
-  const { name, code, description, github, dateCreated } = project
+  const { name, code, description, github, dateCreated, pathname, coverImagePathname } = project
+  const url = getLocalizedPath({ locale, pathname })
   const baseUrl = getBaseUrl()
 
   const jsonLd: WithContext<SoftwareSourceCode> = {
@@ -73,7 +73,7 @@ const Page = async (props: PageProps<'/[locale]/projects/[slug]'>) => {
       name: MY_NAME,
       url: baseUrl
     },
-    thumbnailUrl: `${baseUrl}/images/projects/${slug}/cover.png`,
+    thumbnailUrl: `${baseUrl}${coverImagePathname}`,
     inLanguage: locale
   }
 
@@ -83,7 +83,7 @@ const Page = async (props: PageProps<'/[locale]/projects/[slug]'>) => {
       <div className='mx-auto max-w-3xl'>
         <Header {...project} />
         <BlurImage
-          src={`/images/projects/${slug}/cover.png`}
+          src={coverImagePathname}
           width={1200}
           height={630}
           alt={name}

--- a/apps/web/src/app/[locale]/(main)/projects/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/projects/page.tsx
@@ -55,13 +55,17 @@ const Page = async (props: PageProps<'/[locale]/projects'>) => {
     url,
     mainEntity: {
       '@type': 'ItemList',
-      itemListElement: projects.map((project, index) => ({
-        '@type': 'SoftwareSourceCode',
-        name: project.name,
-        description: project.description,
-        url: `${url}/${project.slug}`,
-        position: index + 1
-      }))
+      itemListElement: projects.map((project, index) => {
+        const projectUrl = getLocalizedPath({ locale, pathname: project.pathname })
+
+        return {
+          '@type': 'SoftwareSourceCode',
+          name: project.name,
+          description: project.description,
+          url: projectUrl,
+          position: index + 1
+        }
+      })
     },
     isPartOf: {
       '@type': 'WebSite',

--- a/apps/web/src/app/[locale]/(main)/terms/og-image.png/route.tsx
+++ b/apps/web/src/app/[locale]/(main)/terms/og-image.png/route.tsx
@@ -24,7 +24,7 @@ export const GET = async (_request: Request, props: RouteContext<'/[locale]/term
 
     const ogImageFonts = await getOGImageFonts(title)
 
-    return new ImageResponse(<OGImage title={title} url='/terms' />, {
+    return new ImageResponse(<OGImage title={title} url={page.pathname} />, {
       width: OG_IMAGE_WIDTH,
       height: OG_IMAGE_HEIGHT,
       fonts: ogImageFonts

--- a/apps/web/src/app/[locale]/(main)/terms/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/terms/page.tsx
@@ -19,13 +19,18 @@ export const generateMetadata = async (props: PageProps<'/[locale]/terms'>): Pro
   const t = await getTranslations({ locale, namespace: 'terms' })
   const title = t('title')
   const description = t('description')
+  const page = allPages.find((p) => p.slug === 'terms' && p.locale === locale)
+
+  if (!page) {
+    return {}
+  }
 
   return createMetadata({
-    pathname: '/terms',
+    pathname: page.pathname,
     title,
     description,
     locale,
-    ogImagePathname: '/terms/og-image.png'
+    ogImagePathname: page.ogImagePathname
   })
 }
 

--- a/apps/web/src/app/[locale]/(main)/uses/og-image.png/route.tsx
+++ b/apps/web/src/app/[locale]/(main)/uses/og-image.png/route.tsx
@@ -24,7 +24,7 @@ export const GET = async (_request: Request, props: RouteContext<'/[locale]/uses
 
     const ogImageFonts = await getOGImageFonts(title)
 
-    return new ImageResponse(<OGImage title={title} url='/uses' />, {
+    return new ImageResponse(<OGImage title={title} url={page.pathname} />, {
       width: OG_IMAGE_WIDTH,
       height: OG_IMAGE_HEIGHT,
       fonts: ogImageFonts

--- a/apps/web/src/app/[locale]/(main)/uses/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/uses/page.tsx
@@ -24,13 +24,18 @@ export const generateMetadata = async (props: PageProps<'/[locale]/uses'>): Prom
   const t = await getTranslations({ locale, namespace: 'uses' })
   const title = t('title')
   const description = t('description')
+  const page = allPages.find((p) => p.slug === 'uses' && p.locale === locale)
+
+  if (!page) {
+    return {}
+  }
 
   return createMetadata({
-    pathname: '/uses',
+    pathname: page.pathname,
     title,
     description,
     locale,
-    ogImagePathname: '/uses/og-image.png'
+    ogImagePathname: page.ogImagePathname
   })
 }
 
@@ -42,8 +47,14 @@ const Page = async (props: PageProps<'/[locale]/uses'>) => {
   const t = await getTranslations()
   const title = t('uses.title')
   const description = t('uses.description')
-  const url = getLocalizedPath({ locale, pathname: '/uses' })
   const page = allPages.find((p) => p.slug === 'uses' && p.locale === locale)
+
+  if (!page) {
+    return notFound()
+  }
+
+  const { code, pathname } = page
+  const url = getLocalizedPath({ locale, pathname })
 
   const jsonLd: WithContext<WebPage> = {
     '@context': 'https://schema.org',
@@ -57,12 +68,6 @@ const Page = async (props: PageProps<'/[locale]/uses'>) => {
       url: getBaseUrl()
     }
   }
-
-  if (!page) {
-    return notFound()
-  }
-
-  const { code } = page
 
   return (
     <>

--- a/apps/web/src/app/rss.xml/route.ts
+++ b/apps/web/src/app/rss.xml/route.ts
@@ -9,14 +9,15 @@ import { getBaseUrl } from '@/utils/get-base-url'
 
 export const GET = async () => {
   const t = await getTranslations({ locale: i18n.defaultLocale })
+  const baseUrl = getBaseUrl()
 
   const feed = new RSS({
     title: MY_NAME,
     description: t('metadata.site-description'),
-    site_url: getBaseUrl(),
-    feed_url: `${getBaseUrl()}/rss.xml`,
+    site_url: baseUrl,
+    feed_url: `${baseUrl}/rss.xml`,
     language: 'en-US',
-    image_url: `${getBaseUrl()}/og-image.png`
+    image_url: `${baseUrl}/og-image.png`
   })
 
   const posts = allPosts.filter((p) => p.locale === i18n.defaultLocale)
@@ -24,7 +25,7 @@ export const GET = async () => {
   for (const post of posts) {
     feed.item({
       title: post.title,
-      url: `${getBaseUrl()}/blog/${post.slug}`,
+      url: `${baseUrl}${post.pathname}`,
       date: post.date,
       description: post.summary,
       author: MY_NAME

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -12,9 +12,9 @@ const sitemap = (): MetadataRoute.Sitemap => {
     '/guestbook',
     '/projects',
     '/dashboard',
-    ...new Set(allPages.map((page) => `/${page.slug}`)),
-    ...new Set(allProjects.map((project) => `/projects/${project.slug}`)),
-    ...new Set(allPosts.map((post) => `/blog/${post.slug}`))
+    ...new Set(allPages.map((page) => page.pathname)),
+    ...new Set(allProjects.map((project) => project.pathname)),
+    ...new Set(allPosts.map((post) => post.pathname))
   ]
 
   return supportedLanguages.flatMap((locale) => {

--- a/apps/web/src/components/home/latest-articles.tsx
+++ b/apps/web/src/components/home/latest-articles.tsx
@@ -111,7 +111,7 @@ const Card = (props: CardProps) => {
   const likesQuery = usePostLikeCount({ slug: post.slug })
 
   return (
-    <Link href={`/blog/${post.slug}`} className='group relative rounded-xl p-2 shadow-feature-card'>
+    <Link href={post.pathname} className='group relative rounded-xl p-2 shadow-feature-card'>
       <div className='flex items-center justify-between p-4'>
         <div className='flex items-center gap-3'>
           <PencilIcon className='size-[18px]' />
@@ -119,13 +119,7 @@ const Card = (props: CardProps) => {
         </div>
         <ArrowUpRightIcon className='size-[18px] opacity-0 transition-opacity group-hover:opacity-100' />
       </div>
-      <BlurImage
-        width={1200}
-        height={630}
-        src={`/images/blog/${post.slug}/cover.png`}
-        alt={post.title}
-        className='rounded-lg'
-      />
+      <BlurImage width={1200} height={630} src={post.coverImagePathname} alt={post.title} className='rounded-lg' />
       <div className='flex items-center justify-between gap-2 px-2 pt-4 text-sm text-zinc-500'>
         {formattedDate}
         <div className='flex gap-2'>

--- a/apps/web/src/components/home/selected-projects.tsx
+++ b/apps/web/src/components/home/selected-projects.tsx
@@ -101,11 +101,11 @@ const SelectedProjects = (props: SelectedProjectsProps) => {
 
 const Card = (props: CardProps) => {
   const { project } = props
-  const { slug, name, description } = project
+  const { name, description, pathname, coverImagePathname } = project
   const t = useTranslations()
 
   return (
-    <Link key={slug} href={`/projects/${slug}`} className='group relative rounded-xl p-2 shadow-feature-card'>
+    <Link href={pathname} className='group relative rounded-xl p-2 shadow-feature-card'>
       <div className='flex items-center justify-between p-4'>
         <div className='flex items-center gap-3'>
           <LightbulbIcon className='size-[18px]' />
@@ -116,7 +116,7 @@ const Card = (props: CardProps) => {
       <BlurImage
         width={1200}
         height={630}
-        src={`/images/projects/${slug}/cover.png`}
+        src={coverImagePathname}
         alt={description}
         className='rounded-lg'
         lazy={false}

--- a/apps/web/src/components/post-cards.tsx
+++ b/apps/web/src/components/post-cards.tsx
@@ -29,7 +29,7 @@ const PostCards = (props: PostCardsProps) => {
 }
 
 const PostCard = (props: PostCardProps) => {
-  const { slug, title, summary, date } = props
+  const { slug, title, summary, date, pathname, coverImagePathname } = props
   const formattedDate = useFormattedDate(date)
   const t = useTranslations()
 
@@ -37,9 +37,9 @@ const PostCard = (props: PostCardProps) => {
   const likesQuery = usePostLikeCount({ slug })
 
   return (
-    <Link href={`/blog/${slug}`} className='group rounded-xl px-2 py-4 shadow-feature-card'>
+    <Link href={pathname} className='group rounded-xl px-2 py-4 shadow-feature-card'>
       <BlurImage
-        src={`/images/blog/${slug}/cover.png`}
+        src={coverImagePathname}
         className='rounded-lg'
         width={1200}
         height={630}

--- a/apps/web/src/components/project-cards.tsx
+++ b/apps/web/src/components/project-cards.tsx
@@ -24,12 +24,12 @@ const ProjectCards = (props: ProjectCardsProps) => {
 }
 
 const ProjectCard = (props: ProjectCardProps) => {
-  const { name, description, techstack, slug } = props
+  const { name, description, techstack, pathname, coverImagePathname } = props
 
   return (
-    <Link href={`/projects/${slug}`} className='group rounded-xl px-2 py-4 shadow-feature-card'>
+    <Link href={pathname} className='group rounded-xl px-2 py-4 shadow-feature-card'>
       <BlurImage
-        src={`/images/projects/${slug}/cover.png`}
+        src={coverImagePathname}
         width={1200}
         height={630}
         imageClassName='group-hover:scale-105'


### PR DESCRIPTION
## Summary
- add a reusable transform in the web content collections to expose path, asset, and source metadata on every document
- migrate blog, project, and page consumers to rely on the new metadata for links, OG images, and edit URLs
- refresh sitemap and RSS generation to leverage the derived pathnames for locale-aware URLs

## Testing
- pnpm --filter @repo/web build:mdx
- pnpm --filter @repo/web lint

------
https://chatgpt.com/codex/tasks/task_e_68d8d74b6a90832cb4ed46462a54a7b6